### PR TITLE
Handle all ALIEN_INSTALL_TYPE values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ os:
 osx_image: xcode7.3
 
 env:
-  - ALIEN_INSTALL_TYPE=share FORCE_MATRIX=1
-  - ALIEN_INSTALL_TYPE=system FORCE_MATRIX=0
-  - FORCE_MATRIX=1
+  - ALIEN_INSTALL_TYPE=share TYPE_DEFINED=1
+  - ALIEN_INSTALL_TYPE=default TYPE_DEFINED=1
+  - TYPE_DEFINED=0
 
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ os:
 
 osx_image: xcode7.3
 
+env:
+  - ALIEN_INSTALL_TYPE=share FORCE_MATRIX=1
+  - ALIEN_INSTALL_TYPE=system FORCE_MATRIX=0
+
 matrix:
   exclude:
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ osx_image: xcode7.3
 env:
   - ALIEN_INSTALL_TYPE=share FORCE_MATRIX=1
   - ALIEN_INSTALL_TYPE=system FORCE_MATRIX=0
+  - FORCE_MATRIX=1
 
 matrix:
   exclude:

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for perl distribution Alien-KentSrc
 
+0.4 Not Released
+ - change timing of setting machtype to avoid when users set ALIEN_INSTALL_TYPE
+ - minimum perl is 5.8.9
+
 0.3 2018-03-07T13:13:29+1300
  - include jkweb.a as well
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,6 +10,7 @@ WriteMakefile($abmm->mm_args(
   DISTNAME      => 'Alien-KentSrc',
   NAME          => 'Alien::KentSrc',
   VERSION_FROM  => 'lib/Alien/KentSrc.pm',
+  MIN_PERL_VERSION => '5.008009',
 ));
 
 sub MY::postamble {

--- a/alienfile
+++ b/alienfile
@@ -4,11 +4,6 @@ use warnings;
 use alienfile;
 use File::Spec::Functions qw{catfile};
 
-probe sub {
-  chomp(my $type = `uname -m`);
-  shift->runtime_prop->{kent_machtype} = $type;
-  return 'share';
-};
 probe [ 'env | grep -q ^KENT_SRC=' ];
 probe [ 'env | grep -q ^MACHTYPE=' ];
 
@@ -24,6 +19,15 @@ share {
   );
 
   plugin 'Extract' => ( format => 'zip' );
+
+  meta->before_hook(
+    build => sub {
+      my ($build) = @_;
+      chomp(my $type = `uname -m`);
+      $build->runtime_prop->{kent_machtype} = $type;
+      log("set MACHTYPE to $type");
+    }
+  );
 
   build [
     ## make jkweb.a
@@ -44,7 +48,7 @@ share {
 
   meta->after_hook(
     gather_share => sub {
-      my($build) = @_;
+      my ($build) = @_;
       $build->runtime_prop->{version} =
         join '.', split //, $build->runtime_prop->{version};
       $build->runtime_prop->{cflags} = join ' ',

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,5 @@
 # -*- mode: perl; -*-
+requires 'perl' => '5.008009';
 requires 'Alien::Base' => 0;
 requires 'Alien::Base::ModuleBuild' => 0;
 requires 'Archive::Zip' => 0;


### PR DESCRIPTION
Using `probe` was the wrong way to set the runtime property. Setting `ALIEN_INSTALL_TYPE=share` results in no call to probe, hence it is never set.